### PR TITLE
chore: add root build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,19 @@ Thumbs.db
 
 # Landing page (not for OSS distribution)
 maria-code-lp/
+
+# Root level build artifacts (should not be committed)
+chunk-*.js
+chunk-*.js.map
+enhanced-cli*.js
+enhanced-cli*.js.map
+enhanced-cli*.cjs
+enhanced-cli*.cjs.map
+simple*.js
+simple*.js.map
+simple*.cjs
+simple*.cjs.map
+index.js
+index.js.map
+index.cjs
+index.cjs.map


### PR DESCRIPTION
Clean up repository by ignoring build artifacts that shouldn't be committed:
- chunk-*.js and map files
- enhanced-cli*.js/cjs and map files
- simple*.js/cjs and map files
- index.js/cjs and map files

These are build outputs that were accidentally tracked in the root directory.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to prevent certain build artifact files from being committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->